### PR TITLE
VSNetBeans 31.0.1 preparation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "netbeans"]
 	path = netbeans
 	url = https://github.com/apache/netbeans.git
+	branch = release310


### PR DESCRIPTION
NetBeans submodule to point to latest commit [f8ac37e](https://github.com/apache/netbeans/commits/release310/) on NetBeans IDE `release310` branch. `.gitmodules` updated on VSNetBeans `release3101` branch as well.